### PR TITLE
github deploy action and lazy loader features

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,32 @@
+# Deploy to VPS when code is pushed/merged to staging.
+# Uses environment "emmanuels-env" for secrets: VPS_HOST, VPS_USERNAME, SSH_PRIVATE_KEY
+
+name: Deploy to Staging (VPS)
+
+on:
+  push:
+    branches:
+      - staging
+
+jobs:
+  deploy:
+    name: Deploy frontend to VPS
+    runs-on: ubuntu-latest
+    environment: emmanuels-env
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            set -e
+            cd /home/emmanuel/notes_crud/frontend
+            git fetch origin
+            git checkout staging
+            git pull origin staging
+            npm ci
+            npm run build
+            rsync -av --delete dist/ /var/www/notes/
+            echo "Deploy finished. Static files updated in /var/www/notes"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,10 +59,14 @@ const router = createBrowserRouter([
                 <NoteForm />
               </Suspense>
             ),
-            loader: () => {
-              return import("./components/Notes/NoteForm").then((module) =>
-                module.loadTagsAndCategories()
-              );
+            // loader: () => {
+            //   return import("./components/Notes/NoteForm").then((module) =>
+            //     module.loadTagsAndCategories()
+            //   );
+            // },
+            loader: async () => {
+              const module = await import("./components/Notes/NoteForm");
+              return module.loadTagsAndCategories();
             },
           },
           {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,40 +1,91 @@
-import './styles.css';
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from "react-router-dom";
+import "./styles.css";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import RootLayout from "./components/RootLayout";
-import Notes, { loadNotes, loadArchivedNotes } from "./components/Notes/Notes";
 import ErrorPage from "./components/ErrorPage";
 import Login from "./components/Login";
 import ProtectedComponent from "./components/ProtectedComponent";
 import SignUp from "./components/SignUp";
-import NoteForm, { loadNoteDetail, loadTagsAndCategories } from './components/Notes/NoteForm';
+import { loadNoteDetail } from "./components/Notes/NoteForm";
+import { lazy, Suspense } from "react";
 
-export const appURL = import.meta.env.VITE_APP_URL || '/notes-app/';
+export const appURL = import.meta.env.VITE_APP_URL || "/notes-app/";
 
-const router = createBrowserRouter([{
-  path: appURL,
-  element: <RootLayout />,
-  errorElement: <ErrorPage />,
-  children: [
-    { index: true, element: <Login /> },
-    { path: 'signup', element: <SignUp /> },
-    {
-      path: 'notes', element: <ProtectedComponent />,
-      children: [
-        { index: true, element: <Notes />, loader: loadNotes },
-        { path: 'archived', element: <Notes />, loader: loadArchivedNotes },
-        { path: 'new', element: <NoteForm />, loader: loadTagsAndCategories },
-        { path: ':noteId/edit', element: <NoteForm />, loader: loadNoteDetail },
-      ]
-    },
-  ]
-}]);
+// Lazy loading components
+const Notes = lazy(() => import("./components/Notes/Notes"));
+const NoteForm = lazy(() => import("./components/Notes/NoteForm"));
 
+const router = createBrowserRouter([
+  {
+    path: appURL,
+    element: <RootLayout />,
+    // errorElement: <ErrorPage />,
+    children: [
+      { index: true, element: <Login /> },
+      { path: "signup", element: <SignUp /> },
+      {
+        path: "notes",
+        element: <ProtectedComponent />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Suspense fallback={<p>Loading...</p>}>
+                <Notes />
+              </Suspense>
+            ),
+            loader: () => {
+              return import("./components/Notes/Notes").then((module) =>
+                module.loadNotes()
+              );
+            },
+          },
+          {
+            path: "archived",
+            element: (
+              <Suspense fallback={<p>Loading...</p>}>
+                <Notes />
+              </Suspense>
+            ),
+            loader: () => {
+              return import("./components/Notes/Notes").then((module) =>
+                module.loadArchivedNotes()
+              );
+            },
+          },
+          {
+            path: "new",
+            element: (
+              <Suspense fallback={<p>Loading...</p>}>
+                <NoteForm />
+              </Suspense>
+            ),
+            loader: () => {
+              return import("./components/Notes/NoteForm").then((module) =>
+                module.loadTagsAndCategories()
+              );
+            },
+          },
+          {
+            path: ":noteId/edit",
+            element: (
+              <Suspense fallback={<p>Loading...</p>}>
+                <NoteForm />
+              </Suspense>
+            ),
+            loader: (meta) => {
+              return import("./components/Notes/NoteForm").then((module) =>
+                module.loadNoteDetail(meta)
+              );
+            },
+          },
+        ],
+      },
+    ],
+  },
+]);
 
 function App() {
-  return <RouterProvider router={router} />
+  return <RouterProvider router={router} />;
 }
 
 export default App;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces an automated deploy pipeline with SSH + remote commands and changes route loading behavior; misconfiguration or loader/import issues could break staging deploys or route navigation.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`deploy-staging.yml`) that auto-deploys the frontend to a VPS on pushes to `staging` by SSHing in, pulling the latest code, running `npm ci`/`npm run build`, and `rsync`ing `dist/` to `/var/www/notes/`.
> 
> Updates `src/App.jsx` to lazy-load `Notes` and `NoteForm` via `React.lazy`/`Suspense`, and changes route loaders to dynamically import the modules and call `loadNotes`, `loadArchivedNotes`, `loadTagsAndCategories`, and `loadNoteDetail` at navigation time (also removes the router `errorElement` hookup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cab6a8a770a04ea49386e51151498a4e0ff0fbc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->